### PR TITLE
第１章　自分の面談日程の表示・登録・編集・削除機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'devise-i18n'
 # Use dotenv to set environment variables
 gem 'dotenv-rails'
 
-# Use enum_help for translate element of enum into Japanese
+# Use enum_help to translate elements of enum into Japanese
 gem 'enum_help'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem 'devise-i18n'
 # Use dotenv to set environment variables
 gem 'dotenv-rails'
 
+# Use enum_help for translate element of enum into Japanese
+gem 'enum_help'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
@@ -184,6 +186,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  enum_help
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)

--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,9 @@
 class InterviewsController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
+    @user = current_user
+    @interviews = current_user.interviews
   end
 
   def new

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -13,7 +13,7 @@ class InterviewsController < ApplicationController
   def create
     @interview = current_user.interviews.build(interview_params)
     if @interview.save
-      flash[:notice] = "面接候補日を追加しました"
+      flash[:notice] = "面談候補日を追加しました"
       redirect_to user_interviews_path
     else
       render 'new'
@@ -26,7 +26,7 @@ class InterviewsController < ApplicationController
 
   def update
     if Interview.find(params[:id]).update_attributes(interview_params)
-      flash[:notice] = "面接候補日を更新しました"
+      flash[:notice] = "面談候補日を更新しました"
       redirect_to user_interviews_path
     else
       render 'edit'
@@ -35,7 +35,7 @@ class InterviewsController < ApplicationController
 
   def destroy
     Interview.find(params[:id]).destroy
-    flash[:notice] = "面接候補日を削除しました"
+    flash[:notice] = "面談候補日を削除しました"
     redirect_to user_interviews_path
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -16,7 +16,8 @@ class InterviewsController < ApplicationController
       flash[:notice] = "面接候補日を追加しました"
       redirect_to user_interviews_path
     else
-
+      @interviews = current_user.interviews
+      render '/interviews/new'
     end
   end
 
@@ -25,5 +26,4 @@ class InterviewsController < ApplicationController
     def interview_params
       params.require(:interview).permit(:start_time)
     end
-
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -21,6 +21,20 @@ class InterviewsController < ApplicationController
     end
   end
 
+  def edit
+    @interview = Interview.find(params[:id])
+  end
+
+  def update
+    @interview = Interview.find(params[:id])
+    if @interview.update_attributes(interview_params)
+      flash[:notice] = "面接候補日を更新しました"
+      redirect_to user_interviews_path
+    else
+      render 'edit'
+    end
+  end
+
   private
 
     def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -25,8 +25,7 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    @interview = Interview.find(params[:id])
-    if @interview.update_attributes(interview_params)
+    if Interview.find(params[:id]).update_attributes(interview_params)
       flash[:notice] = "面接候補日を更新しました"
       redirect_to user_interviews_path
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,10 @@
+class InterviewsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,14 +1,29 @@
 class InterviewsController < ApplicationController
   before_action :authenticate_user!
-  
+
   def index
     @user = current_user
     @interviews = current_user.interviews
   end
 
   def new
+    @interview = Interview.new
   end
 
   def create
+    @interview = current_user.interviews.build(interview_params)
+    if @interview.save
+      flash[:notice] = "面接候補日を追加しました"
+      redirect_to user_interviews_path
+    else
+
+    end
   end
+
+  private
+
+    def interview_params
+      params.require(:interview).permit(:start_time)
+    end
+
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -25,7 +25,8 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    if Interview.find(params[:id]).update_attributes(interview_params)
+    @interview = Interview.find(params[:id])
+    if @interview.update_attributes(interview_params)
       flash[:notice] = "面談候補日を更新しました"
       redirect_to user_interviews_path
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -16,8 +16,7 @@ class InterviewsController < ApplicationController
       flash[:notice] = "面接候補日を追加しました"
       redirect_to user_interviews_path
     else
-      @interviews = current_user.interviews
-      render '/interviews/new'
+      render 'new'
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -34,6 +34,12 @@ class InterviewsController < ApplicationController
     end
   end
 
+  def destroy
+    Interview.find(params[:id]).destroy
+    flash[:notice] = "面接候補日を削除しました"
+    redirect_to user_interviews_path
+  end
+
   private
 
     def interview_params

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -3,14 +3,13 @@ class Interview < ApplicationRecord
   default_scope -> { order(:start_time) }
   validates :start_time, presence: true
   validates :status, presence: true
-  validates :user_id,  presence: true
   enum status: { pending: 0, approved: 1, rejected: 2 }
   validate :is_the_date_the_future?
 
   private
 
     def is_the_date_the_future?
-      if start_time < DateTime.now
+      if start_time.past?
         errors.add(:start_time, "は未来の時間を指定してください")
       end
     end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,7 +1,17 @@
 class Interview < ApplicationRecord
   belongs_to :user
+  default_scope -> { order(:start_time) }
   validates :start_time, presence: true
   validates :status, presence: true
   validates :user_id,  presence: true
   enum status: { pending: 0, approved: 1, rejected: 2 }
+  validate :is_the_date_the_future?
+
+  private
+
+    def is_the_date_the_future?
+      if start_time < DateTime.now
+        errors.add(:start_time, "は未来の時間を指定してください")
+      end
+    end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,7 @@
+class Interview < ApplicationRecord
+  belongs_to :user
+  validates :start_time, presence: true
+  validates :status, presence: true
+  validates :user_id,  presence: true
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  has_many :interviews
   validates :name,  presence: true
   validates :birthdate,  presence: true
   validates :gender,  presence: true

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -24,3 +24,9 @@
 <% end %>
 <br />
 <%= render "devise/shared/links" %>
+
+
+<hr>
+<h3>テストアカウント</h3>
+<p>Email: 1@test.com</p>
+<p>Password: password</p>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -2,5 +2,5 @@
   <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
   <td><%= interview.status_i18n %></td>
   <td><%= button_to '編集', edit_user_interview_path(current_user.id, interview.id), method: :get, class: "btn btn-default", disabled: !interview.pending? %></td>
-  <td></td>
+  <td><%= button_to '削除', user_interview_path(current_user.id, interview.id), method: :delete, class: "btn btn-danger", disabled: !interview.pending? %></td>
 </tr>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
   <td><%= interview.status_i18n %></td>
-  <td><%= button_to '編集', edit_user_interview_path(current_user.id, interview.id), method: :get, class: "btn btn-default" %></td>
+  <td><%= button_to '編集', edit_user_interview_path(current_user.id, interview.id), method: :get, class: "btn btn-default", disabled: !interview.pending? %></td>
   <td></td>
 </tr>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
-  <td><%= interview.status %></td>
+  <td><%= interview.status_i18n %></td>
   <td></td>
   <td></td>
 </tr>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
   <td><%= interview.status_i18n %></td>
-  <td></td>
+  <td><%= button_to '編集', edit_user_interview_path(current_user.id, interview.id), method: :get, class: "btn btn-default" %></td>
   <td></td>
 </tr>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
+  <td><%= interview.status %></td>
+  <td></td>
+  <td></td>
+</tr>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -2,5 +2,5 @@
   <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
   <td><%= interview.status_i18n %></td>
   <td><%= button_to '編集', edit_user_interview_path(current_user.id, interview.id), method: :get, class: "btn btn-default", disabled: !interview.pending? %></td>
-  <td><%= button_to '削除', user_interview_path(current_user.id, interview.id), method: :delete, class: "btn btn-danger", disabled: !interview.pending? %></td>
+  <td><%= button_to '削除', user_interview_path(current_user.id, interview.id), method: :delete, class: "btn btn-danger", disabled: !interview.pending?, data: { confirm: '本当に削除しますか？' } %></td>
 </tr>

--- a/app/views/interviews/_interview_form.html.erb
+++ b/app/views/interviews/_interview_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_for([current_user, @interview]) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="field">
+    <%= f.label :start_time, '開始時間' %><br />
+    <%= f.datetime_select :start_time, default: Time.now + 1.week %>
+  </div>
+  <br />
+  <div class="actions">
+    <%= f.submit "追加", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/interviews/_interview_form.html.erb
+++ b/app/views/interviews/_interview_form.html.erb
@@ -6,6 +6,6 @@
   </div>
   <br />
   <div class="actions">
-    <%= f.submit "追加", class: "btn btn-primary" %>
+    <%= f.submit button, class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/interviews/create.html.erb
+++ b/app/views/interviews/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#create</h1>
+<p>Find me in app/views/interviews/create.html.erb</p>

--- a/app/views/interviews/create.html.erb
+++ b/app/views/interviews/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Interviews#create</h1>
-<p>Find me in app/views/interviews/create.html.erb</p>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,3 +1,3 @@
-<h1>面接候補日の編集</h1>
+<h1>面談候補日の編集</h1>
 
 <%= render 'interview_form', interview: @interview %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>面談候補日の編集</h1>
 
-<%= render 'interview_form', interview: @interview %>
+<%= render 'interview_form', interview: @interview, button: '更新' %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>面接候補日の編集</h1>
+
+<%= render 'interview_form', interview: @interview %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#index</h1>
+<p>Find me in app/views/interviews/index.html.erb</p>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,17 +1,21 @@
 <h1><%= current_user.name %>さんの面接一覧</h1>
 
-<table class="table table-bordered table-hover table-striped table-condensed text-center">
-  <thead>
-    <tr>
-      <th class="text-center">面接開始時間</th>
-      <th class="text-center">承認状態</th>
-      <th colspan="2"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render partial: 'interview', collection: @interviews %>
-  </tbody>
-</table>
+<% if @interviews.any? %>
+  <table class="table table-bordered table-hover table-striped table-condensed text-center">
+    <thead>
+      <tr>
+        <th class="text-center">面接開始時間</th>
+        <th class="text-center">承認状態</th>
+        <th colspan="2"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'interview', collection: @interviews %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="alert alert alert-danger">候補日が登録されていません。</p>
+<% end %>
 
 <div class="row">
   <div class="col-sm-10">

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,10 +1,10 @@
-<h1><%= current_user.name %>さんの面接一覧</h1>
+<h1><%= current_user.name %>さんの面談一覧</h1>
 
 <% if @interviews.any? %>
   <table class="table table-bordered table-hover table-striped table-condensed text-center">
     <thead>
       <tr>
-        <th class="text-center">面接開始時間</th>
+        <th class="text-center">開始時間</th>
         <th class="text-center">承認状態</th>
         <th colspan="2"></th>
       </tr>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,2 +1,14 @@
-<h1>Interviews#index</h1>
-<p>Find me in app/views/interviews/index.html.erb</p>
+<h1><%= current_user.name %>さんの面接一覧</h1>
+
+<table class="table table-bordered table-hover table-striped table-condensed text-center">
+  <thead>
+    <tr>
+      <th class="text-center">面接開始時間</th>
+      <th class="text-center">承認状態</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'interview', collection: @interviews %>
+  </tbody>
+</table>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -12,3 +12,11 @@
     <%= render partial: 'interview', collection: @interviews %>
   </tbody>
 </table>
+
+<div class="row">
+  <div class="col-sm-10">
+  </div>
+  <div class="col-sm-2">
+    <%= button_to '候補日追加', new_user_interview_path, method: :get, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#new</h1>
+<p>Find me in app/views/interviews/new.html.erb</p>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,2 +1,12 @@
-<h1>Interviews#new</h1>
-<p>Find me in app/views/interviews/new.html.erb</p>
+<h1>面接候補日の追加</h1>
+
+<%= form_for(@interview, url: user_interviews_path) do |f| %>
+  <div class="field">
+    <%= f.label :start_time, '開始時間' %><br />
+    <%= f.datetime_select :start_time %>
+  </div>
+  <br />
+  <div class="actions">
+    <%= f.submit "登録", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,3 +1,3 @@
 <h1>面談候補日の追加</h1>
 
-<%= render 'interview_form', interview: @interview %>
+<%= render 'interview_form', interview: @interview, button: '追加' %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,3 +1,3 @@
-<h1>面接候補日の追加</h1>
+<h1>面談候補日の追加</h1>
 
 <%= render 'interview_form', interview: @interview %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,12 +1,3 @@
 <h1>面接候補日の追加</h1>
 
-<%= form_for(@interview, url: user_interviews_path) do |f| %>
-  <div class="field">
-    <%= f.label :start_time, '開始時間' %><br />
-    <%= f.datetime_select :start_time %>
-  </div>
-  <br />
-  <div class="actions">
-    <%= f.submit "登録", class: "btn btn-primary" %>
-  </div>
-<% end %>
+<%= render 'interview_form', interview: @interview %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
       <nav>
         <ul class="nav navbar-nav navbar-left">
           <li><%= link_to "プロフィール", edit_user_registration_path %></li>
-          <li><%= link_to "自分の面接一覧", '#' %></li>
+          <li><%= link_to "自分の面接一覧", user_interviews_path(current_user.id) %></li>
           <li><%= link_to "メール", '#' %></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
       <nav>
         <ul class="nav navbar-nav navbar-left">
           <li><%= link_to "プロフィール", edit_user_registration_path %></li>
-          <li><%= link_to "自分の面接一覧", user_interviews_path(current_user.id) %></li>
+          <li><%= link_to "自分の面談一覧", user_interviews_path(current_user.id) %></li>
           <li><%= link_to "メール", '#' %></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,7 +6,6 @@
         <ul class="nav navbar-nav navbar-left">
           <li><%= link_to "プロフィール", edit_user_registration_path %></li>
           <li><%= link_to "自分の面談一覧", user_interviews_path(current_user.id) %></li>
-          <li><%= link_to "メール", '#' %></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,10 +12,10 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% if notice %>
-        <p class="notice"><%= notice %></p>
+        <p class="notice alert alert-success"><%= notice %></p>
       <% end %>
       <% if alert %>
-        <p class="alert"><%= alert %></p>
+        <p class="alert alert alert-danger"><%= alert %></p>
       <% end %>
       <%= yield %>
     </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      <% object.errors.full_messages.each do |msg| %>
+        <%= msg %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,8 @@ module ENavigator
 
     # Translate devise into Japanese
     config.i18n.default_locale = :ja
+
+    # Set time zone to Tokyo
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,9 @@ ja:
         school: "学校名"
         email: "メールアドレス"
         password: "パスワード"
+      interview:
+        start_time: "開始時間"
+        status: "承認状態"
   date:
     abbr_day_names:
     - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,3 +212,9 @@ ja:
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
     pm: 午後
+  enums:
+    interview:
+      status:
+        pending: 保留
+        approved: 承認
+        rejected: 却下

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'users#index'
+
+  resources :users, only: :index do
+    resources :interviews
+  end
 end

--- a/db/migrate/20180118044952_create_interviews.rb
+++ b/db/migrate/20180118044952_create_interviews.rb
@@ -1,0 +1,11 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.datetime :start_time, null: false
+      t.integer :status, default: 0, null: false, limit: 2
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180123141441_remove_condition_from_interviews.rb
+++ b/db/migrate/20180123141441_remove_condition_from_interviews.rb
@@ -1,0 +1,5 @@
+class RemoveConditionFromInterviews < ActiveRecord::Migration[5.1]
+  def change
+    change_column :interviews, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180109143933) do
+ActiveRecord::Schema.define(version: 20180118044952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "start_time", null: false
+    t.integer "status", limit: 2, default: 0, null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_interviews_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -36,4 +45,5 @@ ActiveRecord::Schema.define(version: 20180109143933) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "interviews", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180118044952) do
+ActiveRecord::Schema.define(version: 20180123141441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "interviews", force: :cascade do |t|
     t.datetime "start_time", null: false
-    t.integer "status", limit: 2, default: 0, null: false
+    t.integer "status", default: 0, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,23 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# ユーザー
+5.times do |n|
+  email = "#{n + 1}@test.com"
+  password = "password"
+  name  = "ユーザー#{n + 1}"
+  birthdate = "199#{n}-10-2#{n}"
+  gender = n % 2
+  school = "第#{n + 1}大学"
+  User.create!(email: email,
+               password: password,
+               name: name,
+               birthdate: birthdate,
+               gender: gender,
+               school: school)
+end
+
+# インタビュー
+users = User.all
+6.times do |n|
+  start_time = "2018-02-1#{n} 1#{n}:2#{n}:00"
+  users.each { |user| user.interviews.create!(start_time: start_time,
+                                              user_id: user.id) }
+end


### PR DESCRIPTION
やりたかったこと
---

- 自分の面談日程に関する以下機能の追加
  - 表示
  - 登録
  - 編集
  - 削除


やったこと
----

- 面接日程（Interview）のモデルとコントローラを作成。
併せて以下アクションと対応するビューを実装。
  - index：面接日程の一覧画面の表示
    - index.html
  - new：面接日程の登録画面の表示
    - new.html
  - create：面接日程の登録
  - edit：面接日程の編集画面の表示
    - edit.html
  - update：面接日程の更新
  - destroy：面接日程の削除
- タイムゾーンを東京に設定
- enum_help gem の導入


動作確認方法
---

- [ ] ユーザーを新規で作成（またはトップページ記載のテストアカウントを使用）してログインする
- [ ] ヘッダーのメニューから「自分の面談一覧」を表示する
- [ ] 画面下部の「候補日追加」ボタンを押下し、追加画面に遷移する
- [ ] 開始時間に現在以前の日時を設定後、「追加」ボタンを押下するとエラーメッセージが表示される
- [ ] 開始時間に現在以降の日時を設定後、「追加」ボタンを押下すると一覧画面に遷移する
追加メッセージが表示され、面談日程が追加される
- [ ] 追加した面接日程の「編集」ボタンを押下し、編集画面に遷移する
- [ ] 開始時間を変更し、「更新」ボタンを押下する
更新メッセージが表示され、面談日程が更新される
- [ ] 更新した面談日程の「削除」ボタンを押下し、確認ダイアログで「キャンセル」ボタンを押下すると何も起こらない
- [ ] 更新した面談日程の「削除」ボタンを押下し、確認ダイアログで「OK」ボタンを押下すると削除メッセージが表示され、面談日程が削除される


その他
---

-  enum_help gem の使用
面談一覧画面でstatus（承認状態）を表示する際、enumのキーを日本語で簡単に出力するために使いました。
が、極一部のためにgemを導入してja.ymlで定義して…というのは以下と比べると、かえってわかりづらくなるのでは、と迷っています。
https://qiita.com/yuch_i/items/fa823a5ee3d569859137
どう思われますでしょうか？

