### PR TITLE
第２章　面接官が面談日程を承認 or 拒否するための機能

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -26,11 +26,19 @@ class InterviewsController < ApplicationController
 
   def update
     @interview = Interview.find(params[:id])
-    if @interview.update_attributes(interview_params)
-      flash[:notice] = "面談候補日を更新しました"
-      redirect_to user_interviews_path
+    user_id = @interview.user_id
+    if user_id == current_user.id
+      if @interview.update_attributes(interview_params)
+        flash[:notice] = "面談候補日を更新しました"
+        redirect_to user_interviews_path
+      else
+        render 'edit'
+      end
     else
-      render 'edit'
+      interviews = Interview.where(user_id: user_id).update_all(status: :rejected)
+      @interview.approved!
+      flash[:notice] = "面談日を設定しました"
+      redirect_to user_interviews_path
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -13,8 +13,8 @@ class InterviewsController < ApplicationController
   def create
     @interview = current_user.interviews.build(interview_params)
     if @interview.save
-      flash[:notice] = "面談候補日を追加しました"
-      redirect_to user_interviews_path
+      flash.now[:notice] = "面談候補日を追加しました"
+      render 'show'
     else
       render 'new'
     end
@@ -29,16 +29,16 @@ class InterviewsController < ApplicationController
     user_id = @interview.user_id
     if user_id == current_user.id
       if @interview.update_attributes(interview_params)
-        flash[:notice] = "面談候補日を更新しました"
-        redirect_to user_interviews_path
+        flash.now[:notice] = "面談候補日を更新しました"
+        render 'show'
       else
         render 'edit'
       end
     else
       interviews = Interview.where(user_id: user_id).update_all(status: :rejected)
       @interview.approved!
-      flash[:notice] = "面談日を設定しました"
-      redirect_to user_interviews_path
+      flash.now[:notice] = "面談日を設定しました"
+      render 'show'
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -2,8 +2,8 @@ class InterviewsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @user = current_user
-    @interviews = current_user.interviews
+    @user = User.find(params[:user_id])
+    @interviews = @user.interviews
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @users = User.where.not(id: current_user.id)
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def interview_datetime(start_time)
+    start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[start_time.wday]}) %H時%M分")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,9 @@ class User < ApplicationRecord
   validates :gender,  presence: true
   validates :school,  presence: true
   enum gender: { male:0, female:1 }
+
+  def age
+    date_format = "%Y%m%d"
+    (Date.today.strftime(date_format).to_i - birthdate.strftime(date_format).to_i) / 10000
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,5 +28,5 @@
 
 <hr>
 <h3>テストアカウント</h3>
-<p>Email: 1@test.com</p>
+<p>Email: 1@example.com</p>
 <p>Password: password</p>

--- a/app/views/interviews/_interview.html.erb
+++ b/app/views/interviews/_interview.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= interview.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[interview.start_time.wday]}) %H時%M分") %></td>
+  <td><%= interview_datetime(interview.start_time) %></td>
   <td><%= interview.status_i18n %></td>
   <td><%= button_to '編集', edit_user_interview_path(current_user.id, interview.id), method: :get, class: "btn btn-default", disabled: !interview.pending? %></td>
   <td><%= button_to '削除', user_interview_path(current_user.id, interview.id), method: :delete, class: "btn btn-danger", disabled: !interview.pending?, data: { confirm: '本当に削除しますか？' } %></td>

--- a/app/views/interviews/_mine.html.erb
+++ b/app/views/interviews/_mine.html.erb
@@ -1,0 +1,24 @@
+<% if @interviews.any? %>
+  <table class="table table-bordered table-hover table-striped table-condensed text-center">
+    <thead>
+      <tr>
+        <th class="text-center">開始時間</th>
+        <th class="text-center">承認状態</th>
+        <th colspan="2"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'interview', collection: @interviews %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="alert alert alert-danger">候補日が登録されていません。</p>
+<% end %>
+
+<div class="row">
+  <div class="col-sm-10">
+  </div>
+  <div class="col-sm-2">
+    <%= button_to '候補日追加', new_user_interview_path, method: :get, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/app/views/interviews/_mine.html.erb
+++ b/app/views/interviews/_mine.html.erb
@@ -12,7 +12,7 @@
     </tbody>
   </table>
 <% else %>
-  <p class="alert alert alert-danger">候補日が登録されていません。</p>
+  <p class="alert alert-info">候補日が登録されていません。</p>
 <% end %>
 
 <div class="row">

--- a/app/views/interviews/_others.html.erb
+++ b/app/views/interviews/_others.html.erb
@@ -1,0 +1,16 @@
+<h3>現在の面接日程</h3>
+<% if @interviews.approved.any? %>
+  <p><strong><%= interview_datetime(@interviews.approved.first.start_time) %></strong>に面接が設定されています。</p>
+<% else %>
+  <p>面接が設定されていません。 </p>
+<% end %>
+<hr>
+<% if @interviews.any? %>
+  <p>面接日程を変更する場合は以下から選んでください。</p>
+  <% @interviews.each do |interview| %>
+    <%= button_to interview_datetime(interview.start_time), '#', method: :get, class: "btn btn-primary" %>
+    <br />
+  <% end %>
+<% else %>
+  <p>面接候補日が登録されていません。</p>
+<% end %>

--- a/app/views/interviews/_others.html.erb
+++ b/app/views/interviews/_others.html.erb
@@ -5,10 +5,12 @@
   <p>面接が設定されていません。 </p>
 <% end %>
 <hr>
-<% if @interviews.any? %>
+<h3>その他の面接候補日</h3>
+<% not_approved_interviews = @interviews.where.not(status: :approved) %>
+<% if not_approved_interviews.any? %>
   <p>面接日程を変更する場合は以下から選んでください。</p>
-  <% @interviews.each do |interview| %>
-    <%= button_to interview_datetime(interview.start_time), '#', method: :get, class: "btn btn-primary" %>
+  <% not_approved_interviews.each do |interview| %>
+    <%= button_to interview_datetime(interview.start_time), user_interview_path(interview.user_id, interview.id), method: :patch, class: "btn btn-primary" %>
     <br />
   <% end %>
 <% else %>

--- a/app/views/interviews/_others.html.erb
+++ b/app/views/interviews/_others.html.erb
@@ -1,18 +1,18 @@
-<h3>現在の面接日程</h3>
+<h3>現在の面談日程</h3>
 <% if @interviews.approved.any? %>
-  <p><strong><%= interview_datetime(@interviews.approved.first.start_time) %></strong>に面接が設定されています。</p>
+  <p><strong><%= interview_datetime(@interviews.approved.first.start_time) %></strong>に面談が設定されています。</p>
 <% else %>
-  <p>面接が設定されていません。 </p>
+  <p>面談が設定されていません。 </p>
 <% end %>
 <hr>
-<h3>その他の面接候補日</h3>
+<h3>その他の面談候補日</h3>
 <% not_approved_interviews = @interviews.where.not(status: :approved) %>
 <% if not_approved_interviews.any? %>
-  <p>面接日程を変更する場合は以下から選んでください。</p>
+  <p>面談日程を変更する場合は以下から選んでください。</p>
   <% not_approved_interviews.each do |interview| %>
     <%= button_to interview_datetime(interview.start_time), user_interview_path(interview.user_id, interview.id), method: :patch, class: "btn btn-primary" %>
     <br />
   <% end %>
 <% else %>
-  <p>面接候補日が登録されていません。</p>
+  <p>面談候補日が登録されていません。</p>
 <% end %>

--- a/app/views/interviews/_others.html.erb
+++ b/app/views/interviews/_others.html.erb
@@ -10,7 +10,7 @@
 <% if not_approved_interviews.any? %>
   <p>面談日程を変更する場合は以下から選んでください。</p>
   <% not_approved_interviews.each do |interview| %>
-    <%= button_to interview_datetime(interview.start_time), user_interview_path(interview.user_id, interview.id), method: :patch, class: "btn btn-primary" %>
+    <%= button_to interview_datetime(interview.start_time), user_interview_path(interview.user_id, interview.id), method: :patch, class: "btn btn-primary", data: { confirm: "#{interview_datetime(interview.start_time)}で面談を確定してよろしいですか？" } %>
     <br />
   <% end %>
 <% else %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,26 +1,7 @@
-<h1><%= current_user.name %>さんの面談一覧</h1>
+<h1><%= @user.name %>さんの面談一覧</h1>
 
-<% if @interviews.any? %>
-  <table class="table table-bordered table-hover table-striped table-condensed text-center">
-    <thead>
-      <tr>
-        <th class="text-center">開始時間</th>
-        <th class="text-center">承認状態</th>
-        <th colspan="2"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <%= render partial: 'interview', collection: @interviews %>
-    </tbody>
-  </table>
+<% if @user.id == current_user.id %>
+  <%= render partial: 'mine', interviews: @interviews%>
 <% else %>
-  <p class="alert alert alert-danger">候補日が登録されていません。</p>
+  <%= render partial: 'others', interviews: @interviews %>
 <% end %>
-
-<div class="row">
-  <div class="col-sm-10">
-  </div>
-  <div class="col-sm-2">
-    <%= button_to '候補日追加', new_user_interview_path, method: :get, class: "btn btn-primary" %>
-  </div>
-</div>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,0 +1,3 @@
+<p><strong>開始時間：</strong><%= interview_datetime(@interview.start_time) %></p>
+<p><strong>承認状態：</strong><%= @interview.status_i18n %></p>
+<%= button_to "面談一覧", user_interviews_path, method: :get, class: "btn btn-primary" %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -4,6 +4,6 @@
   <td><%= user.age %></td>
   <td><%= user.gender_i18n %></td>
   <td><%= user.school %></td>
-  <td><%= user.interviews.approved.first.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[user.interviews.approved.first.start_time.wday]}) %H時%M分") if user.interviews.approved.count > 0 %></td>
+  <td><%= interview_datetime(user.interviews.approved.first.start_time) if user.interviews.approved.count > 0 %></td>
   <td><%= button_to '面接一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>
 </tr>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -2,7 +2,7 @@
   <td><%= user.name %></td>
   <td><%= user.email %></td>
   <td><%= user.age %></td>
-  <td><%= user.gender %></td>
+  <td><%= user.gender_i18n %></td>
   <td><%= user.school %></td>
   <td>面接日時（要修正）</td>
   <td><%= button_to '面接一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -4,6 +4,6 @@
   <td><%= user.age %></td>
   <td><%= user.gender_i18n %></td>
   <td><%= user.school %></td>
-  <td><%= interview_datetime(user.interviews.approved.first.start_time) if user.interviews.approved.count > 0 %></td>
+  <td><%= interview_datetime(user.interviews.approved.first.start_time) if user.interviews.approved.any? %></td>
   <td><%= button_to '面談一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>
 </tr>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= user.name %></td>
   <td><%= user.email %></td>
-  <td>user.age（要修正）</td>
+  <td><%= user.age %></td>
   <td><%= user.gender %></td>
   <td><%= user.school %></td>
   <td>面接日時（要修正）</td>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -5,5 +5,5 @@
   <td><%= user.gender_i18n %></td>
   <td><%= user.school %></td>
   <td><%= interview_datetime(user.interviews.approved.first.start_time) if user.interviews.approved.count > 0 %></td>
-  <td><%= button_to '面接一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>
+  <td><%= button_to '面談一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>
 </tr>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td><%= user.name %></td>
+  <td><%= user.email %></td>
+  <td>user.age（要修正）</td>
+  <td><%= user.gender %></td>
+  <td><%= user.school %></td>
+  <td>面接日時（要修正）</td>
+  <td><%= button_to '面接一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>
+</tr>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -4,6 +4,6 @@
   <td><%= user.age %></td>
   <td><%= user.gender_i18n %></td>
   <td><%= user.school %></td>
-  <td>面接日時（要修正）</td>
+  <td><%= user.interviews.approved.first.start_time.strftime("%Y年%m月%d日(#{%w(日 月 火 水 木 金 土)[user.interviews.approved.first.start_time.wday]}) %H時%M分") if user.interviews.approved.count > 0 %></td>
   <td><%= button_to '面接一覧', user_interviews_path(user.id), method: :get, class: "btn btn-default" %></td>
 </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,22 @@
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>
+<h1>ユーザー一覧</h1>
+
+<% if @users.any? %>
+  <table class="table table-bordered table-hover table-striped table-condensed text-center">
+    <thead>
+      <tr>
+        <th class="text-center">名前</th>
+        <th class="text-center">Email</th>
+        <th class="text-center">年齢</th>
+        <th class="text-center">性別</th>
+        <th class="text-center">学校名</th>
+        <th class="text-center">面接日時</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'user', collection: @users %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="alert alert alert-danger">他のユーザーが存在しません。</p>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -221,3 +221,7 @@ ja:
         pending: 保留
         approved: 承認
         rejected: 却下
+    user:
+      gender:
+        male: 男性
+        female: 女性

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # ユーザー
 5.times do |n|
-  email = "#{n + 1}@test.com"
+  email = "#{n + 1}@example.com"
   password = "password"
   name  = "ユーザー#{n + 1}"
   birthdate = "199#{n}-10-2#{n}"


### PR DESCRIPTION
やりたかったこと
---

**第1節**
- 自分以外のユーザーの一覧をトップページに表示する
  - 名前やメールアドレスなどのユーザー情報、他の人の面接一覧を表示するページへのリンクも表示する

**第2節**
- 面接官用の面接日程一覧ページを作る
  - どの日程で面接を行うか選択できるようにする

**第3節**
- 面談日程を承認or拒否できるようにする
  - 面接日程一覧ページで選択した日程が面接日であること（承認）を保存する
  - 他の日が面接日でないこと（却下）も保存する


やったこと
----

**第1節**
- ユーザー一覧を表示するために、UsersController#index及び対応するビューを実装
- ユーザーの年齢を表示するために、User#ageを実装
- ユーザーの性別を日本語で表示するために、ja.ymlを修正
- ユーザーの面接日時を指定のフォーマットで出力するために、ApplicationHelper#interview_datetime(start_time)を実装
  - べた書きしていた「自分の面談一覧」の日時もヘルパーでの表示に修正

**第2節**
- 面接日程一覧にアクセスしたユーザーが本人か他のユーザー（面接官）かに応じて、表示するパーシャルを変えるように修正
  - 本人の場合のパーシャルは、上記修正前の通り
- 他のユーザー（面接官）の場合のパーシャルを実装

**第3節**
- InterviewsController#updateをリクエストしたユーザーが本人か他のユーザー（面接官）かに応じて、処理を変えるよう修正
  - 本人の場合の処理は、上記修正前の通り
- 他のユーザー（面接官）の場合の処理を実装

**その他**
  - [test.comやaaa.comをテストデータに使うのはやめましょうという話](https://blog.ko31.com/201304/sample-domain-example/)を読んで、テストデータのメールアドレスを「〜@test.com」から「〜@example.com」に修正
  - InterviewsController#create,updateの後、indexビューにリダイレクトする仕様になっていたが、サンプルアプリに合わせて、showビューをレンダーするよう修正

動作確認方法
---

- [ ] トップページ記載のテストアカウントを使用してログインする
- [ ] トップページにユーザー一覧が表示される
- [ ] 「ユーザー2」の「面談一覧」ボタンを押下し、「ユーザー2さんの面談一覧」に遷移する
- [ ] 「現在の面談日程」に、面談が設定されていない旨、メッセージが表示される
- [ ] *1* 「その他の面談候補日」から任意の日程のボタンを押下し、確認ダイアログで「OK」ボタンを押下する
- [ ] *2* 面談日を設定した旨、メッセージが表示される
- [ ] *3* 画面下部の「面談一覧」ボタンを押下し、「ユーザー2さんの面談一覧」に戻る
- [ ] *4* 「現在の面談日程」に設定した日程が表示される
- [ ] *5* 「その他の面談候補日」に設定した日程以外が表示される
- [ ] *1*〜*5*を繰り返し、1回目に設定した日程が2回目の設定後は「その他の面談候補日」に表示される
- [ ] ヘッダーから「自分の面談一覧」を開くと、「ユーザー2さんの面談一覧」とは異なる表示がされる
- [ ] ヘッダーからログアウトし、トップページ記載のテストアカウントの数字を2に変えてログインする
- [ ] ヘッダーから「自分の面談一覧」を開くと、*1*で設定した日程のみ「承認状態」が「承認」に、その他の日程は「却下」になっている
- [ ] すべての「編集」「削除」ボタンが非活性になっている